### PR TITLE
Handle no settings.py gracefully in import_products_from_shopify example

### DIFF
--- a/SDKs/python_sdk/import_products_from_shopify_csv/import_products.py
+++ b/SDKs/python_sdk/import_products_from_shopify_csv/import_products.py
@@ -2,8 +2,12 @@ import csv
 import sys
 
 from builton_sdk import Builton
-from settings import CSV_DELIMITER, API_KEY, BEARER_TOKEN
 from termcolor import cprint
+
+try:
+    from settings import CSV_DELIMITER, API_KEY, BEARER_TOKEN
+except ImportError:
+    from settings_example import CSV_DELIMITER
 
 """
     MAPPING: Shopify and BuiltOn Product
@@ -25,13 +29,17 @@ from termcolor import cprint
 =======================================================
     Info: The field `properties` is a dictionary. You can fill it as you want, and the keys `grams`,
      `vendor` etc are just examples.
-    
+
 """
 
 
 def main(api_key=None, bearer_token=None):
-    api_key = api_key if api_key is not None else API_KEY
-    bearer_token = bearer_token if bearer_token is not None else BEARER_TOKEN
+    try:
+        api_key = api_key if api_key is not None else API_KEY
+        bearer_token = bearer_token if bearer_token is not None else BEARER_TOKEN
+    except NameError:
+        cprint("Missing API_KEY and BEARER_TOKEN in settings.py", "red")
+        return
 
     builton = Builton(api_key=api_key, bearer_token=bearer_token)
     cprint("BuiltOn SDK is ready!", "cyan")


### PR DESCRIPTION
Right now, if you are missing the settings.py it fails because of the imported module. 
![Screenshot 2019-09-03 at 15 41 33](https://user-images.githubusercontent.com/6033889/64178246-67322580-ce61-11e9-95f8-e236fcb97292.png)

Just added a conditional import and some error handling 
![Screenshot 2019-09-03 at 15 42 50](https://user-images.githubusercontent.com/6033889/64178296-816c0380-ce61-11e9-95b1-833bbc5008c3.png)


